### PR TITLE
fix version doesn't work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build: clean
 	@go generate $(shell go list)/...
 	@go build \
 		-tags "netgo static_build" -installsuffix netgo \
-		-ldflags "-w -X $(shell go list).Version=$(VERSION) -X $(shell go list).Commit=$(COMMIT)" \
+		-ldflags "-w -X main.Version=$(VERSION) -X main.Commit=$(COMMIT)" \
 		.
 
 install: build


### PR DESCRIPTION
#27 

we use `-ldflags` option to modify the value of the `Version` and `Commit` variable, but the import path is main, not  "github.com/prologic/tube".  so I change `$(shell go list)`  to `main` in Makefile.

to test it works or not, just type `make`, the output is:
```sh
Removing tube
tube version v1.1.12@d36fb86
```
it works!









